### PR TITLE
Add basic legal pages and doc updates

### DIFF
--- a/DEPLOYMENT-CHECKLIST.md
+++ b/DEPLOYMENT-CHECKLIST.md
@@ -67,6 +67,14 @@
 ### Performance Issues
 - **Issue**: Slow page load times
 - **Solution**: Optimize images, implement proper code splitting, and use Next.js performance features
-\`\`\`
 
-Let's also update the environment variables utility to ensure it's properly handling the required variables:
+## Environment Utility
+Ensure `lib/env.ts` validates required variables and provides helpful errors. Example:
+
+```ts
+export function getEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing environment variable ${name}`)
+  return value
+}
+```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -59,6 +59,9 @@ If you encounter issues during deployment:
 2. Verify that all environment variables are set correctly
 3. Try deploying from a clean branch
 4. Contact Vercel support if issues persist
-\`\`\`
 
 ### 3.2 Create a Skip Link for Accessibility
+Add a skip link near the top of the page so keyboard and screen reader users can bypass
+the navigation. Include a link that jumps to `#main-content` and becomes visible when
+focused. This project provides a `SkipLink` component that you can add in
+`app/layout.tsx` before the main content wrapper.

--- a/app/disclosures/page.tsx
+++ b/app/disclosures/page.tsx
@@ -1,0 +1,20 @@
+import Layout from "@/components/layout"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Disclosures | Structured Partners",
+  description: "Important disclosures and regulatory information."
+}
+
+export default function DisclosuresPage() {
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-16">
+        <h1 className="font-serif text-4xl font-bold mb-6">Disclosures</h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Relevant disclosures will appear on this page in the future.
+        </p>
+      </div>
+    </Layout>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next"
 import "./globals.css"
 // Import the SkipLink component
 import SkipLink from "@/components/skip-link"
+import A11yAnnouncer from "@/components/a11y-announcer"
+import AnalyticsProvider from "@/components/analytics-provider"
 // Import the Providers component
 import { Providers } from "./providers"
 
@@ -21,11 +23,14 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <SkipLink />
-        <Providers>
-          <div id="main-content" tabIndex={-1}>
-            {children}
-          </div>
-        </Providers>
+        <AnalyticsProvider>
+          <Providers>
+            <A11yAnnouncer />
+            <div id="main-content" tabIndex={-1}>
+              {children}
+            </div>
+          </Providers>
+        </AnalyticsProvider>
       </body>
     </html>
   )

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -1,0 +1,20 @@
+import Layout from "@/components/layout"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Structured Partners",
+  description: "Learn how we collect, use, and protect your information."
+}
+
+export default function PrivacyPolicyPage() {
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-16">
+        <h1 className="font-serif text-4xl font-bold mb-6">Privacy Policy</h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          This page outlines our commitment to safeguarding your data. Content will be updated soon.
+        </p>
+      </div>
+    </Layout>
+  )
+}

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -1,0 +1,20 @@
+import Layout from "@/components/layout"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Sitemap | Structured Partners",
+  description: "Overview of available pages on our site."
+}
+
+export default function SitemapPage() {
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-16">
+        <h1 className="font-serif text-4xl font-bold mb-6">Sitemap</h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          A structured list of site pages will be added here soon.
+        </p>
+      </div>
+    </Layout>
+  )
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,20 @@
+import Layout from "@/components/layout"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Structured Partners",
+  description: "Review the terms and conditions for using our website."
+}
+
+export default function TermsPage() {
+  return (
+    <Layout>
+      <div className="container mx-auto px-4 py-16">
+        <h1 className="font-serif text-4xl font-bold mb-6">Terms of Service</h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          The full terms of service will be posted here shortly.
+        </p>
+      </div>
+    </Layout>
+  )
+}

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -283,7 +283,7 @@ export default function ContactForm() {
 
           <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
             By submitting this form, you agree to our{" "}
-            <a href="/privacy" className="underline hover:text-primary">
+            <a href="/privacy-policy" className="underline hover:text-primary">
               Privacy Policy
             </a>
           </p>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -161,7 +161,7 @@ export default function Footer() {
                 </div>
                 <p className="text-xs text-gray-500">
                   By subscribing, you agree to our{" "}
-                  <Link href="/privacy" className="underline hover:text-primary">
+                  <Link href="/privacy-policy" className="underline hover:text-primary">
                     Privacy Policy
                   </Link>
                 </p>
@@ -222,7 +222,7 @@ export default function Footer() {
         <div className="border-t border-gray-200 mt-8 pt-8 flex flex-col md:flex-row justify-between items-center">
           <p className="text-gray-500 text-sm">&copy; {currentYear} Structured Partners. All rights reserved.</p>
           <div className="mt-4 md:mt-0 flex flex-wrap gap-4">
-            <Link href="/privacy" className="text-gray-500 text-sm hover:text-primary">
+            <Link href="/privacy-policy" className="text-gray-500 text-sm hover:text-primary">
               Privacy Policy
             </Link>
             <Link href="/terms" className="text-gray-500 text-sm hover:text-primary">


### PR DESCRIPTION
## Summary
- add missing footer pages (Privacy Policy, Terms, Disclosures, Sitemap)
- link the footer and contact form to the new privacy policy URL
- integrate A11yAnnouncer and AnalyticsProvider in the layout
- complete truncated sections in DEPLOYMENT docs

## Testing
- `npm run lint` *(fails: next not found)*
- `node scripts/pre-deployment-test.js`