### PR TITLE
Add AnalyticsProvider to layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,8 @@ import "./globals.css"
 import SkipLink from "@/components/skip-link"
 // Import the Providers component
 import { Providers } from "./providers"
+// Import the AnalyticsProvider component
+import AnalyticsProvider from "@/components/analytics-provider"
 
 export const metadata: Metadata = {
   title: "v0 App",
@@ -21,11 +23,13 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <SkipLink />
-        <Providers>
-          <div id="main-content" tabIndex={-1}>
-            {children}
-          </div>
-        </Providers>
+        <AnalyticsProvider>
+          <Providers>
+            <div id="main-content" tabIndex={-1}>
+              {children}
+            </div>
+          </Providers>
+        </AnalyticsProvider>
       </body>
     </html>
   )

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -122,19 +122,16 @@ class Analytics {
     this.events = []
 
     try {
-      // In a real implementation, this would send to your analytics endpoint
-      console.log("Sending analytics events:", eventsToSend)
-
-      // Simulate sending to backend
-      // await fetch('/api/analytics', {
-      //   method: 'POST',
-      //   headers: { 'Content-Type': 'application/json' },
-      //   body: JSON.stringify({
-      //     userId: this.userId,
-      //     sessionId: this.sessionId,
-      //     events: eventsToSend
-      //   })
-      // })
+      // Send events to backend endpoint
+      await fetch("/api/analytics", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId: this.userId,
+          sessionId: this.sessionId,
+          events: eventsToSend,
+        }),
+      })
     } catch (error) {
       // If sending fails, add events back to queue
       console.error("Failed to send analytics events:", error)


### PR DESCRIPTION
## Summary
- integrate `AnalyticsProvider` into the root layout so navigation events are tracked
- send analytics events to `/api/analytics` instead of logging to the console

## Testing
- `npm run lint` *(fails: `next` not found)*