### PR TITLE
Add openGraph metadata to static pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -14,6 +14,19 @@ export const metadata: Metadata = {
     "deal sherpa",
     "exit strategy experts",
   ],
+  openGraph: {
+    title: "About Us | Structured Partners",
+    description:
+      "Founded on the principle that M&A advisors should truly understand the businesses they represent. Learn about our team and our approach.",
+    images: [
+      {
+        url: "/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Structured Partners - About Us",
+      },
+    ],
+  },
 }
 
 export default function AboutPage() {

--- a/app/affiliations/page.tsx
+++ b/app/affiliations/page.tsx
@@ -7,6 +7,19 @@ export const metadata: Metadata = {
   title: "Affiliations & Partnerships | Structured Partners",
   description:
     "Explore our industry affiliations and partnerships that help us deliver exceptional value to our clients in the building products and services industry.",
+  openGraph: {
+    title: "Affiliations & Partnerships | Structured Partners",
+    description:
+      "Explore our industry affiliations and partnerships that help us deliver exceptional value to our clients in the building products and services industry.",
+    images: [
+      {
+        url: "/images/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Structured Partners - Affiliations",
+      },
+    ],
+  },
 }
 
 export default function AffiliationsPage() {


### PR DESCRIPTION
## Summary
- add openGraph info to About page
- add openGraph info to Affiliations page

## Testing
- `pnpm lint` *(fails: next not found)*