### PR TITLE
Fix Next.js images unoptimized

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,8 +15,13 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    domains: ['images.unsplash.com', 'res.cloudinary.com'],
-    unoptimized: true,
+    domains: [
+      'images.unsplash.com',
+      'res.cloudinary.com',
+      'imagedelivery.net',
+      'imagecdn.app',
+    ],
+    unoptimized: false,
   },
   // Remove the experimental optimizeCss feature that's causing the build error
   // experimental: {


### PR DESCRIPTION
## Summary
- enable Next.js image optimization

## Testing
- `npm run build` *(fails: `next` not found)*